### PR TITLE
Fix: Harden extension security

### DIFF
--- a/background.js
+++ b/background.js
@@ -49,10 +49,11 @@ async function fetchNews() {
   }
 
   try {
-    const response = await fetch(`https://newsapi.org/v2/top-headlines?country=us&apiKey=${currentApiKey}`, {
+    const response = await fetch(`https://newsapi.org/v2/top-headlines?country=us`, {
       headers: {
         'Accept': 'application/json',
-        'User-Agent': 'Chrome Extension'
+        'User-Agent': 'Chrome Extension',
+        'X-Api-Key': currentApiKey
       }
     });
 
@@ -65,6 +66,7 @@ async function fetchNews() {
     
     if (data.articles && data.articles.length > 0) {
       const articles = data.articles.slice(0, 10);
+      // Ensure that any display of these headlines in HTML contexts uses textContent or proper sanitization to prevent XSS.
       const headlines = articles
         .map(article => article.title)
         .join(' +++ ');

--- a/content.js
+++ b/content.js
@@ -85,7 +85,7 @@ function handleTickerClick(event) {
   if (currentHeadlines.length > 0) {
     const firstArticle = currentHeadlines[0];
     if (firstArticle.url) {
-      window.open(firstArticle.url, '_blank');
+      window.open(firstArticle.url, '_blank', 'noopener,noreferrer');
     }
   }
 }
@@ -114,6 +114,7 @@ function updateTicker(text, isError = false, headlines = []) {
     content.onclick = handleTickerClick;
   }
   
+  // Using textContent here is crucial for security as it prevents XSS vulnerabilities from potentially malicious API data.
   content.textContent = text;
   
   // 存储新闻数据


### PR DESCRIPTION
This commit implements several security enhancements:

1.  **API Key Handling:** The API key is now sent via the `X-Api-Key` HTTP header instead of as a query parameter in `background.js`. This is a more secure method as it prevents the key from being logged in URLs.

2.  **Safer Link Opening:** Added `rel="noopener noreferrer"` to `window.open` calls in `content.js` when opening news articles. This improves security by preventing the opened page from controlling the original page or leaking referrer information.

3.  **Security Comments:** Added comments in `content.js` and `background.js` to emphasize the importance of using `textContent` for displaying API-sourced data, reinforcing XSS prevention best practices for future code maintenance.

4.  **Permission Review:** The use of `<all_urls>` in `manifest.json` for the content script was reviewed. While broad, it's considered appropriate for the extension's core functionality of providing a global news ticker. The focus remains on the security of the content script itself.